### PR TITLE
[docs] fix: tap gesture handler function docs

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -124,7 +124,7 @@ In the **EmojiSticker.js** file, import `TapGestureHandler` from `react-native-g
 These hooks will animate the style on the `<AnimatedImage>` component for the sticker when the tap gesture is recognized.
 
 ```jsx EmojiSticker.js
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { TapGestureHandler, State } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -141,19 +141,18 @@ const scaleImage = useSharedValue(imageSize);
 
 Creating a shared value using the `useSharedValue()` hook has many advantages. It helps to mutate a piece of data and allows running animations based on the current value.
 A shared value can be accessed and modified using the `.value` property. It will scale the initial value of `scaleImage` so that when a user double-taps the sticker,
-it scales to twice its original size. To do this, we will create a function and call it `onDoubleTap()`, and this function will use the `useAnimatedGestureHandler()` hook
+it scales to twice its original size. To do this, we will create a function and call it `onDoubleTap()`, and this function will run when `State` of the event is active.
 to animate the transition while scaling the sticker image.
 
 Create the following function in the `<EmojiSticker>` component:
 
 ```jsx EmojiSticker.js
-const onDoubleTap = useAnimatedGestureHandler({
-  onActive: () => {
-    if (scaleImage.value) {
-      scaleImage.value = scaleImage.value * 2;
-    }
-  },
-});
+const onDoubleTap = (event) => {
+    if (event.nativeEvent.state === State.ACTIVE) {
+      if (scaleImage.value) {
+        scaleImage.value = scaleImage.value * 2;
+      }
+    }            
 ```
 
 To animate the transition, let's use a spring-based animation. This will make it feel alive because it's based on the real-world physics of a spring.
@@ -202,7 +201,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
   return (
     <View style={{ top: -350 }}>
-      /* @info Wrap the AnimatedImage component with TapGestureHandler*/ <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>/* @end */
+      /* @info Wrap the AnimatedImage component with TapGestureHandler*/ <TapGestureHandler onHandlerStateChange={onDoubleTap} numberOfTaps={2}>/* @end */
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
@@ -252,7 +251,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     /* @info Replace the View component with AnimatedView */<AnimatedView style={{ top: -350 }}>/* @end */
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <TapGestureHandler onHandlerStateChange={onDoubleTap} numberOfTaps={2}>
         {/* ...rest of the code remains same */}
       </TapGestureHandler>
     /* @info */</AnimatedView>/* @end */


### PR DESCRIPTION
on path  https://github.com/expo/expo/edit/main/docs/pages/tutorial/gestures.mdx

previously 
const onDoubleTap = useAnimatedGestureHandler({
  onActive: () => {
    if (scaleImage.value) {
      scaleImage.value = scaleImage.value * 2;
    }
  },
});

this function was causing a lot of trouble in typescript in Tap Gesture. As a typescript dev, I was struggling to find the actual type mismatch that's why I have changed the 'useAnimatedGestureHandler' hook to the native event handler function  and  'onHandlerStateChange' props in the Tap gesture

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
